### PR TITLE
Fixed certain months not populating from model

### DIFF
--- a/modules/gm.datepickerMultiSelect.js
+++ b/modules/gm.datepickerMultiSelect.js
@@ -51,7 +51,7 @@ angular.module('gm.datepickerMultiSelect', ['ui.bootstrap'])
 				 * Fires after multiSelect model updates, so check to
 				 * see if update was already called this cycle.
 				 **/
-				scope.$parent.$watch('activeDateId', function() {
+				scope.$parent.$watch(function () { return ctrl.activeDate.valueOf(); }, function() {
 					if(!alreadyUpdated)
 						update();
 					alreadyUpdated = false;


### PR DESCRIPTION
If you pre-populate the selected dates with a date in Feb 2015 and a
date in March 2015 you'll find that when you press the next month arrow
to go from Feb to March that the activeDateId watch doesn't fire which
causes the March 2015 date(s) to never be selected. This is because the
UID that ui.bootstrap feeds into activeDateId is actually just the UID
of the user interface's day square. Because of this, any months that are
next to each other and have their 1st day start on the same day of the
week won't have their dates be populated in the view. Switching over to
ctrl.activeDate.valueOf() fixes this.