### PR TITLE
Bugfix: dates should be stored and compared as midnight

### DIFF
--- a/src/gm.datepickerMultiSelect.js
+++ b/src/gm.datepickerMultiSelect.js
@@ -59,7 +59,7 @@ SOFTWARE.
 						if(!newVal)
 							return;
 
-						var dateVal = newVal.getTime(),
+						var dateVal = newVal.setHours(0, 0, 0, 0),
 							selectedDates = scope.selectedDates;
 
 						if (scope.selectRange) {


### PR DESCRIPTION
newVal.getTime() doesn't return midnight value of newVal. Since later on midnight value will be compared to set "selected" attribute of dateObject, dateVal also should be set as midnight value of newVal. 