### PR TITLE
Update gm.datepickerMultiSelect.js

### DIFF
--- a/src/gm.datepickerMultiSelect.js
+++ b/src/gm.datepickerMultiSelect.js
@@ -58,6 +58,15 @@ SOFTWARE.
 					});
 
 					var ngModelCtrl = ctrls[1];
+					var datepickerCtrl = ctrls[0];
+
+					if (ngModelCtrl) {
+							// Listen for 'refreshDatepickers' event... $scope.$broadcast('refreshDatepickers');
+							scope.$on('refreshDatepickers', function refreshView() {
+
+									datepickerCtrl.refreshView();
+							});
+					}
 
 					ngModelCtrl.$viewChangeListeners.push(function() {
 						var newVal = scope.$parent.$eval(attrs.ngModel);


### PR DESCRIPTION
Fix, for refreshDatepickers event.

With this fix, it will possible to call a refresh of datepicker (in example externally change of selected dates, etc.) directly broadcasting the event.

//$scope.activeDate = dt; is not anymore necessary
$scope.$broadcast('refreshDatepickers');